### PR TITLE
Exception thrown when trying to set a temperature

### DIFF
--- a/driver_device_thermostat.groovy
+++ b/driver_device_thermostat.groovy
@@ -468,7 +468,7 @@ def error(error){
 def FormatTemp(temp,invert){
 	if (temp!=null){
 		if(invert){
-			float i=Float.valueOf(temp)
+			float i=Float.parseFloat(temp)
 			switch (location?.getTemperatureScale()) {
 				case "C":
 					return i.round(2)
@@ -481,7 +481,7 @@ def FormatTemp(temp,invert){
 
 		}else{
 
-			float i=Float.valueOf(temp)
+			float i=Float.parseFloat(temp)
 			switch (location?.getTemperatureScale()) {
 				case "C":
 					return i.round(2)


### PR DESCRIPTION
When trying to set a temperature, an exception is thrown with the following message:
 groovy.lang.MissingMethodException: No signature of method: static java.lang.Float.parseFloat() is applicable for argument types: (java.lang.Double) values: [23.5]
Possible solutions: parseFloat(java.lang.String) @line 486 (FormatTemp)